### PR TITLE
fix: backspace in Android not deleting first character

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -539,6 +539,11 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
             selection.format = anchorNode.getFormat();
             selection.style = anchorNode.getStyle();
           }
+          const selectedText = selection.anchor.getNode().getTextContent();
+          if (selectedText.length <= 1) {
+            event.preventDefault();
+            dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);
+          }
         } else {
           event.preventDefault();
           dispatchCommand(editor, DELETE_CHARACTER_COMMAND, true);


### PR DESCRIPTION
Fix for issue: https://github.com/facebook/lexical/issues/5274